### PR TITLE
Add "-y" to ffmpeg command

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -50,5 +50,5 @@ class Predictor(BasePredictor):
         writer.release()
         output_path = "/tmp/output.mp4"
         # ffmpeg command to add codec libx264 to the video
-        subprocess.run(["ffmpeg", "-i", tmpname, "-c:v", "libx264", "-crf", "0", output_path], check=True)
+        subprocess.run(["ffmpeg", "-y", "-i", tmpname, "-c:v", "libx264", "-crf", "0", output_path], check=True)
         return Path(output_path)


### PR DESCRIPTION
Sometimes the model reuses the same environment and fails because a "/tmp/output.mp4" already exists